### PR TITLE
Override instead of adding transferLowerOwnership

### DIFF
--- a/contracts/MultisigOwnable.sol
+++ b/contracts/MultisigOwnable.sol
@@ -27,7 +27,7 @@ abstract contract MultisigOwnable is Ownable {
         realOwner = newRealOwner;
     }
 
-    function transferLowerOwnership(address newOwner) public onlyRealOwner {
+    function transferOwnership(address newOwner) public override onlyRealOwner {
         _transferOwnership(newOwner);
     }
 }


### PR DESCRIPTION
Love these `tubby-cats` contracts!

Currently the `owner` can still call `transferOwnership`: this PR overrides `transferOwnership` (with `onlyRealOwner`) instead of adding `transferLowerOwnership`

I might have missed something here though!